### PR TITLE
Fix warning by removing unused variables

### DIFF
--- a/components/Web_driver/Web_driver.c
+++ b/components/Web_driver/Web_driver.c
@@ -381,8 +381,6 @@ static esp_err_t download_get_handler(httpd_req_t *req)
 static esp_err_t delete_post_handler(httpd_req_t *req)
 {
     char filepath[FILE_PATH_MAX];
-    FILE *fd = NULL;
-    struct stat file_stat;
 
     /* Skip leading "/delete" from URI to get filename */
     /* Note sizeof() counts NULL termination hence the -1 */
@@ -458,7 +456,6 @@ static esp_err_t upload_post_handler(httpd_req_t *req)
 {
     char filepath[FILE_PATH_MAX];
     FILE *fd = NULL;
-    struct stat file_stat;
 
     /* Skip leading "/upload" from URI to get filename */
     /* Note sizeof() counts NULL termination hence the -1 */

--- a/components/Web_driver/Web_driver.c
+++ b/components/Web_driver/Web_driver.c
@@ -381,6 +381,10 @@ static esp_err_t download_get_handler(httpd_req_t *req)
 static esp_err_t delete_post_handler(httpd_req_t *req)
 {
     char filepath[FILE_PATH_MAX];
+#if defined(CONFIG_FS_LITTLEFS) || defined(CONFIG_FS_SPIFFS)
+    FILE *fd = NULL;
+    struct stat file_stat;
+#endif
 
     /* Skip leading "/delete" from URI to get filename */
     /* Note sizeof() counts NULL termination hence the -1 */

--- a/components/Web_driver/Web_driver_json.c
+++ b/components/Web_driver/Web_driver_json.c
@@ -84,7 +84,6 @@ char* Web_driver_json_statusCreate(Web_driver_status_t status){
 char* Web_driver_json_liveCreate(Web_driver_live_t live){
 
 	char *string = NULL;
-	char temp[50];
 
 	cJSON *json = cJSON_CreateObject();
 


### PR DESCRIPTION
Remove unused variables fixes warnings. 